### PR TITLE
Fix dangling pointers in utils/sdl

### DIFF
--- a/utils/sdl/common.odin
+++ b/utils/sdl/common.odin
@@ -9,17 +9,6 @@ import sdl "vendor:sdl2"
 // Package
 import wgpu "../../wrapper"
 
-// Setup surface information
-default_surface_descriptor := wgpu.Surface_Descriptor {
-    Android_Native_Window = nil,
-    Html_Selector         = nil,
-    Metal_Layer           = nil,
-    Wayland_Surface       = nil,
-    Windows_HWND          = nil,
-    Xcb_Window            = nil,
-    Xlib_Window           = nil,
-}
-
 get_sys_info :: proc(window: ^sdl.Window) -> (sdl.SysWMinfo, wgpu.Error_Type) {
     wm_info: sdl.SysWMinfo
     sdl.GetVersion(&wm_info.version)

--- a/utils/sdl/surface_darwin.odin
+++ b/utils/sdl/surface_darwin.odin
@@ -26,8 +26,7 @@ get_surface_descriptor :: proc(
     native_window->contentView()->setLayer(metal_layer)
 
     // Setup surface information
-    descriptor = default_surface_descriptor
-    descriptor.metal_layer = &{layer = metal_layer}
+    descriptor.target = wgpu.Surface_Descriptor_From_Metal_Layer{layer = metal_layer}
 
     return
 }

--- a/utils/sdl/surface_linux.odin
+++ b/utils/sdl/surface_linux.odin
@@ -3,7 +3,6 @@
 package wgpu_utils_sdl
 
 // Core
-import "core:c"
 
 // Vendor
 import sdl "vendor:sdl2"
@@ -20,16 +19,17 @@ get_surface_descriptor :: proc(
     wm_info := get_sys_info(window) or_return
 
     // Setup surface information
-    descriptor = default_surface_descriptor
 
     if wm_info.subsystem == .WAYLAND {
-        descriptor.Wayland_Surface =
-        &{display = wm_info.info.wl.display, surface = wm_info.info.wl.surface}
+        descriptor.target = wgpu.Surface_Descriptor_From_Wayland_Surface{
+            display = wm_info.info.wl.display,
+            surface = wm_info.info.wl.surface,
+        }
     } else if wm_info.subsystem == .X11 {
-        descriptor.Xlib_Window =
-        &{
+        descriptor.target =
+        wgpu.Surface_Descriptor_From_Xlib_Window{
             display = wm_info.info.x11.display,
-            window = cast(c.uint32_t)wm_info.info.x11.window,
+            window = cast(u32)wm_info.info.x11.window,
         }
     }
 

--- a/utils/sdl/surface_windows.odin
+++ b/utils/sdl/surface_windows.odin
@@ -17,9 +17,7 @@ get_surface_descriptor :: proc(
     wm_info := get_sys_info(window) or_return
 
     // Setup surface information
-    descriptor = default_surface_descriptor
-    descriptor.Windows_HWND =
-    &{hinstance = wm_info.info.win.hinstance, hwnd = wm_info.info.win.window}
+    descriptor.target = wgpu.Surface_Descriptor_From_Windows_HWND{hinstance = wm_info.info.win.hinstance, hwnd = wm_info.info.win.window}
 
     return
 }


### PR DESCRIPTION
Changes surface descriptor to use a union instead of a bunch of pointers as discussed in #2, this fixes the dangling pointers in utils/sdl. It also allowed for me to pick up on a missed case in `create_surface` due to type switches enforcing completeness by default.