### PR TITLE
Basic housekeeping on device error handling

### DIFF
--- a/wrapper/adapter.odin
+++ b/wrapper/adapter.odin
@@ -245,12 +245,12 @@ adapter_request_device :: proc(
     device.ptr = res.device
     device.features = device->get_features()
     device.limits = device->get_limits()
-    device.err_scope = new(Error_Scope) // Heap allocate to avoid stack fuckery
-    wgpu.device_set_uncaptured_error_callback(device.ptr, error_scope_callback, device.err_scope)
+    device.err_data = new(Error_Data) // Heap allocate to avoid stack fuckery
+    wgpu.device_set_uncaptured_error_callback(device.ptr, uncaptured_error_callback, device.err_data)
 
     queue := default_queue
     queue.ptr = wgpu.device_get_queue(res.device)
-    queue.err_scope = device.err_scope
+    queue.err_data = device.err_data
 
     device.queue = queue
 

--- a/wrapper/buffer.odin
+++ b/wrapper/buffer.odin
@@ -152,7 +152,7 @@ buffer_map_async :: proc(
         status = .Unknown,
     }
 
-    self.err_scope.info = #procedure
+    self.err_scope.type = .No_Error
 
     self.map_state = .Pending
 
@@ -182,7 +182,7 @@ buffer_set_label :: proc(using self: ^Buffer, label: cstring) {
 // Unmaps the mapped range of the `Buffer` and makes it's contents available for use
 // by the GPU again.
 buffer_unmap :: proc(using self: ^Buffer) -> Error_Type {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.buffer_unmap(ptr)
 

--- a/wrapper/buffer.odin
+++ b/wrapper/buffer.odin
@@ -12,7 +12,7 @@ import wgpu "../bindings"
 Buffer :: struct {
     ptr:          WGPU_Buffer,
     device_ptr:   WGPU_Device,
-    err_scope:    ^Error_Scope,
+    err_data:    ^Error_Data,
     size:         Buffer_Size,
     map_state:    Buffer_Map_State,
     usage:        Buffer_Usage_Flags,
@@ -152,13 +152,13 @@ buffer_map_async :: proc(
         status = .Unknown,
     }
 
-    self.err_scope.type = .No_Error
+    self.err_data.type = .No_Error
 
     self.map_state = .Pending
 
     wgpu.buffer_map_async(self.ptr, mode, offset, size, _buffer_map_callback, &res)
 
-    if self.err_scope.type != .No_Error {
+    if self.err_data.type != .No_Error {
         return .Validation_Error
     }
 
@@ -182,13 +182,13 @@ buffer_set_label :: proc(using self: ^Buffer, label: cstring) {
 // Unmaps the mapped range of the `Buffer` and makes it's contents available for use
 // by the GPU again.
 buffer_unmap :: proc(using self: ^Buffer) -> Error_Type {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.buffer_unmap(ptr)
 
     map_state = .Unmapped
 
-    return err_scope.type
+    return err_data.type
 }
 
 // Release the `Buffer`.

--- a/wrapper/command_encoder.odin
+++ b/wrapper/command_encoder.odin
@@ -10,7 +10,7 @@ import wgpu "../bindings"
 // Encodes a series of GPU operations.
 Command_Encoder :: struct {
     ptr:          WGPU_Command_Encoder,
-    err_scope: ^Error_Scope,
+    err_data: ^Error_Data,
     using vtable: ^Command_Encoder_VTable,
 }
 
@@ -127,7 +127,7 @@ command_encoder_begin_compute_pass :: proc(
 
     compute_pass := default_compute_pass_encoder
     compute_pass.ptr = compute_pass_ptr
-    compute_pass.err_scope = err_scope
+    compute_pass.err_data = err_data
 
     return compute_pass
 }
@@ -251,11 +251,11 @@ command_encoder_clear_buffer :: proc(
     assert(size % 4 == 0, "size must be a multiple of 4")
     assert(offset + size <= buffer.size, "buffer size out of range")
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.command_encoder_clear_buffer(ptr, buffer.ptr, offset, size)
 
-    return err_scope.type
+    return err_data.type
 }
 
 // Copy data from one buffer to another.
@@ -271,7 +271,7 @@ command_encoder_copy_buffer_to_buffer :: proc(
     assert(destination_offset % 4 == 0, "'destination_offset' must be a multiple of 4")
     assert(size % 4 == 0, "'size' must be a multiple of 4")
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.command_encoder_copy_buffer_to_buffer(
         ptr,
@@ -282,7 +282,7 @@ command_encoder_copy_buffer_to_buffer :: proc(
         size,
     )
 
-    return err_scope.type
+    return err_data.type
 }
 
 // Copy data from a buffer to a texture.
@@ -304,11 +304,11 @@ command_encoder_copy_buffer_to_texture :: proc(
         }
     }
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.command_encoder_copy_buffer_to_texture(ptr, source, destination, copy_size)
 
-    return err_scope.type
+    return err_data.type
 }
 
 // Copy data from a texture to a buffer.
@@ -330,11 +330,11 @@ command_encoder_copy_texture_to_buffer :: proc(
         }
     }
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.command_encoder_copy_texture_to_buffer(ptr, source, destination, copy_size)
 
-    return err_scope.type
+    return err_data.type
 }
 
 // Copy data from one texture to another.
@@ -344,11 +344,11 @@ command_encoder_copy_texture_to_texture :: proc(
     destination: ^Image_Copy_Texture,
     copy_size: ^Extent_3D,
 ) -> Error_Type {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.command_encoder_copy_texture_to_texture(ptr, source, destination, copy_size)
 
-    return err_scope.type
+    return err_data.type
 }
 
 // Finish recording. Returns a `Command_Buffer` to submit to `Queue`.
@@ -359,18 +359,18 @@ command_encoder_finish :: proc(
     Command_Buffer,
     Error_Type,
 ) {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     command_buffer_ptr := wgpu.command_encoder_finish(
         ptr,
         &Command_Buffer_Descriptor{label = label},
     )
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if command_buffer_ptr != nil {
             wgpu.command_buffer_release(command_buffer_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     command_buffer := default_command_buffer
@@ -383,30 +383,30 @@ command_encoder_insert_debug_marker :: proc(
     using self: ^Command_Encoder,
     marker_label: cstring,
 ) -> Error_Type {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.command_encoder_insert_debug_marker(ptr, marker_label)
 
-    return err_scope.type
+    return err_data.type
 }
 
 command_encoder_pop_debug_group :: proc(using self: ^Command_Encoder) -> Error_Type {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.command_encoder_pop_debug_group(ptr)
 
-    return err_scope.type
+    return err_data.type
 }
 
 command_encoder_push_debug_group :: proc(
     using self: ^Command_Encoder,
     group_label: cstring,
 ) -> Error_Type {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.command_encoder_push_debug_group(ptr, group_label)
 
-    return err_scope.type
+    return err_data.type
 }
 
 command_encoder_resolve_query_set :: proc(
@@ -417,7 +417,7 @@ command_encoder_resolve_query_set :: proc(
     destination: Buffer,
     destination_offset: u64,
 ) -> Error_Type {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.command_encoder_resolve_query_set(
         ptr,
@@ -428,7 +428,7 @@ command_encoder_resolve_query_set :: proc(
         destination_offset,
     )
 
-    return err_scope.type
+    return err_data.type
 }
 
 command_encoder_set_label :: proc(using self: ^Command_Encoder, label: cstring) {
@@ -440,11 +440,11 @@ command_encoder_write_timestamp :: proc(
     query_set: Query_Set,
     query_index: u32,
 ) -> Error_Type {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.command_encoder_write_timestamp(ptr, query_set.ptr, query_index)
 
-    return err_scope.type
+    return err_data.type
 }
 
 command_encoder_reference :: proc(using self: ^Command_Encoder) {

--- a/wrapper/command_encoder.odin
+++ b/wrapper/command_encoder.odin
@@ -251,7 +251,7 @@ command_encoder_clear_buffer :: proc(
     assert(size % 4 == 0, "size must be a multiple of 4")
     assert(offset + size <= buffer.size, "buffer size out of range")
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.command_encoder_clear_buffer(ptr, buffer.ptr, offset, size)
 
@@ -271,7 +271,7 @@ command_encoder_copy_buffer_to_buffer :: proc(
     assert(destination_offset % 4 == 0, "'destination_offset' must be a multiple of 4")
     assert(size % 4 == 0, "'size' must be a multiple of 4")
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.command_encoder_copy_buffer_to_buffer(
         ptr,
@@ -304,7 +304,7 @@ command_encoder_copy_buffer_to_texture :: proc(
         }
     }
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.command_encoder_copy_buffer_to_texture(ptr, source, destination, copy_size)
 
@@ -330,7 +330,7 @@ command_encoder_copy_texture_to_buffer :: proc(
         }
     }
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.command_encoder_copy_texture_to_buffer(ptr, source, destination, copy_size)
 
@@ -344,7 +344,7 @@ command_encoder_copy_texture_to_texture :: proc(
     destination: ^Image_Copy_Texture,
     copy_size: ^Extent_3D,
 ) -> Error_Type {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.command_encoder_copy_texture_to_texture(ptr, source, destination, copy_size)
 
@@ -359,7 +359,7 @@ command_encoder_finish :: proc(
     Command_Buffer,
     Error_Type,
 ) {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     command_buffer_ptr := wgpu.command_encoder_finish(
         ptr,
@@ -383,7 +383,7 @@ command_encoder_insert_debug_marker :: proc(
     using self: ^Command_Encoder,
     marker_label: cstring,
 ) -> Error_Type {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.command_encoder_insert_debug_marker(ptr, marker_label)
 
@@ -391,7 +391,7 @@ command_encoder_insert_debug_marker :: proc(
 }
 
 command_encoder_pop_debug_group :: proc(using self: ^Command_Encoder) -> Error_Type {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.command_encoder_pop_debug_group(ptr)
 
@@ -402,7 +402,7 @@ command_encoder_push_debug_group :: proc(
     using self: ^Command_Encoder,
     group_label: cstring,
 ) -> Error_Type {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.command_encoder_push_debug_group(ptr, group_label)
 
@@ -417,7 +417,7 @@ command_encoder_resolve_query_set :: proc(
     destination: Buffer,
     destination_offset: u64,
 ) -> Error_Type {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.command_encoder_resolve_query_set(
         ptr,
@@ -440,7 +440,7 @@ command_encoder_write_timestamp :: proc(
     query_set: Query_Set,
     query_index: u32,
 ) -> Error_Type {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.command_encoder_write_timestamp(ptr, query_set.ptr, query_index)
 

--- a/wrapper/compute_pass_encoder.odin
+++ b/wrapper/compute_pass_encoder.odin
@@ -115,7 +115,7 @@ compute_pass_encoder_dispatch_workgroups_indirect :: proc(
 }
 
 compute_pass_encoder_end :: proc(using self: ^Compute_Pass_Encoder) -> Error_Type {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     wgpu.compute_pass_encoder_end(ptr)
 

--- a/wrapper/compute_pass_encoder.odin
+++ b/wrapper/compute_pass_encoder.odin
@@ -5,7 +5,7 @@ import wgpu "../bindings"
 
 Compute_Pass_Encoder :: struct {
     ptr:          WGPU_Compute_Pass_Encoder,
-    err_scope: ^Error_Scope,
+    err_data: ^Error_Data,
     using vtable: ^Compute_Pass_Encoder_VTable,
 }
 
@@ -115,11 +115,11 @@ compute_pass_encoder_dispatch_workgroups_indirect :: proc(
 }
 
 compute_pass_encoder_end :: proc(using self: ^Compute_Pass_Encoder) -> Error_Type {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     wgpu.compute_pass_encoder_end(ptr)
 
-    return err_scope.type
+    return err_data.type
 }
 
 compute_pass_encoder_end_pipeline_statistics_query :: proc(

--- a/wrapper/device.odin
+++ b/wrapper/device.odin
@@ -234,7 +234,7 @@ device_create_bind_group :: proc(
         }
     }
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     bind_group_ptr := wgpu.device_create_bind_group(ptr, &desc)
 
@@ -277,7 +277,7 @@ device_create_bind_group_layout :: proc(
         }
     }
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     bind_group_layout_ptr := wgpu.device_create_bind_group_layout(ptr, &desc)
 
@@ -303,7 +303,7 @@ device_create_buffer :: proc(
     Error_Type,
 ) {
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     buffer_ptr := wgpu.device_create_buffer(ptr, descriptor)
 
@@ -336,7 +336,7 @@ device_create_command_encoder :: proc(
 ) {
     command_encoder := default_gpu_command_encoder
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     if descriptor != nil {
         command_encoder.ptr = wgpu.device_create_command_encoder(ptr, descriptor)
@@ -400,7 +400,7 @@ device_create_compute_pipeline :: proc(
         desc.compute = compute
     }
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     compute_pipeline_ptr := wgpu.device_create_compute_pipeline(ptr, &desc)
 
@@ -464,7 +464,7 @@ device_create_pipeline_layout :: proc(
         }
     }
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     pipeline_layout_ptr := wgpu.device_create_pipeline_layout(ptr, &desc)
 
@@ -510,7 +510,7 @@ device_create_query_set :: proc(
         }
     }
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     query_set_ptr := wgpu.device_create_query_set(ptr, &desc)
 
@@ -749,7 +749,7 @@ device_create_render_pipeline :: proc(
         }
     }
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     render_pipeline_ptr := wgpu.device_create_render_pipeline(ptr, &desc)
 
@@ -773,7 +773,7 @@ device_create_sampler :: proc(
     Sampler,
     Error_Type,
 ) {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     sampler_ptr := wgpu.device_create_sampler(ptr, descriptor)
 
@@ -843,7 +843,7 @@ device_create_shader_module :: proc(
         }
     }
 
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     shader_module_ptr := wgpu.device_create_shader_module(ptr, &desc)
 
@@ -911,7 +911,7 @@ device_create_swap_chain :: proc(
 
         desc.next_in_chain = cast(^Chained_Struct)&extras
     }
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     swap_chain_ptr := wgpu.device_create_swap_chain(ptr, surface.ptr, &desc)
 
@@ -936,7 +936,7 @@ device_create_texture :: proc(
     Texture,
     Error_Type,
 ) {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     texture_ptr := wgpu.device_create_texture(ptr, descriptor)
 

--- a/wrapper/device.odin
+++ b/wrapper/device.odin
@@ -13,7 +13,7 @@ Device :: struct {
     features:     []Feature_Name,
     limits:       Limits,
     queue:        Queue,
-    err_scope:    ^Error_Scope,
+    err_data:    ^Error_Data,
     using vtable: ^Device_VTable,
 }
 
@@ -234,15 +234,15 @@ device_create_bind_group :: proc(
         }
     }
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     bind_group_ptr := wgpu.device_create_bind_group(ptr, &desc)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if bind_group_ptr != nil {
             wgpu.bind_group_release(bind_group_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     bind_group := default_bind_group
@@ -277,15 +277,15 @@ device_create_bind_group_layout :: proc(
         }
     }
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     bind_group_layout_ptr := wgpu.device_create_bind_group_layout(ptr, &desc)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if bind_group_layout_ptr != nil {
             wgpu.bind_group_layout_release(bind_group_layout_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     bind_group_layout := default_bind_group_layout
@@ -303,15 +303,15 @@ device_create_buffer :: proc(
     Error_Type,
 ) {
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     buffer_ptr := wgpu.device_create_buffer(ptr, descriptor)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if buffer_ptr != nil {
             wgpu.buffer_release(buffer_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     wgpu.device_reference(ptr)
@@ -319,7 +319,7 @@ device_create_buffer :: proc(
     buffer := default_buffer
     buffer.ptr = buffer_ptr
     buffer.device_ptr = self.ptr
-    buffer.err_scope = err_scope
+    buffer.err_data = err_data
     buffer.size = descriptor.size
     buffer.usage = descriptor.usage
 
@@ -336,7 +336,7 @@ device_create_command_encoder :: proc(
 ) {
     command_encoder := default_gpu_command_encoder
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     if descriptor != nil {
         command_encoder.ptr = wgpu.device_create_command_encoder(ptr, descriptor)
@@ -347,14 +347,14 @@ device_create_command_encoder :: proc(
         )
     }
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if command_encoder.ptr != nil {
             wgpu.command_encoder_release(command_encoder.ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
-    command_encoder.err_scope = err_scope
+    command_encoder.err_data = err_data
 
     return command_encoder, .No_Error
 }
@@ -400,15 +400,15 @@ device_create_compute_pipeline :: proc(
         desc.compute = compute
     }
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     compute_pipeline_ptr := wgpu.device_create_compute_pipeline(ptr, &desc)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if compute_pipeline_ptr != nil {
             wgpu.compute_pipeline_release(compute_pipeline_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     compute_pipeline := default_compute_pipeline
@@ -464,15 +464,15 @@ device_create_pipeline_layout :: proc(
         }
     }
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     pipeline_layout_ptr := wgpu.device_create_pipeline_layout(ptr, &desc)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if pipeline_layout_ptr != nil {
             wgpu.pipeline_layout_release(pipeline_layout_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     pipeline_layout := default_pipeline_layout
@@ -510,15 +510,15 @@ device_create_query_set :: proc(
         }
     }
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     query_set_ptr := wgpu.device_create_query_set(ptr, &desc)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if query_set_ptr != nil {
             wgpu.query_set_release(query_set_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     query_set := default_query_set
@@ -749,15 +749,15 @@ device_create_render_pipeline :: proc(
         }
     }
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     render_pipeline_ptr := wgpu.device_create_render_pipeline(ptr, &desc)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if render_pipeline_ptr != nil {
             wgpu.render_pipeline_release(render_pipeline_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     render_pipeline := default_render_pipeline
@@ -773,15 +773,15 @@ device_create_sampler :: proc(
     Sampler,
     Error_Type,
 ) {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     sampler_ptr := wgpu.device_create_sampler(ptr, descriptor)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if sampler_ptr != nil {
             wgpu.sampler_release(sampler_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     sampler := default_sampler
@@ -843,15 +843,15 @@ device_create_shader_module :: proc(
         }
     }
 
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     shader_module_ptr := wgpu.device_create_shader_module(ptr, &desc)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if shader_module_ptr != nil {
             wgpu.shader_module_release(shader_module_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     shader_module := default_shader_module
@@ -911,19 +911,19 @@ device_create_swap_chain :: proc(
 
         desc.next_in_chain = cast(^Chained_Struct)&extras
     }
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     swap_chain_ptr := wgpu.device_create_swap_chain(ptr, surface.ptr, &desc)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if swap_chain_ptr != nil {
             wgpu.swap_chain_release(swap_chain_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     swap_chain := default_swap_chain
-    swap_chain.err_scope = err_scope
+    swap_chain.err_data = err_data
     swap_chain.ptr = swap_chain_ptr
 
     return swap_chain, .No_Error
@@ -936,20 +936,20 @@ device_create_texture :: proc(
     Texture,
     Error_Type,
 ) {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     texture_ptr := wgpu.device_create_texture(ptr, descriptor)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if texture_ptr != nil {
             wgpu.texture_release(texture_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     texture := default_texture
     texture.ptr = texture_ptr
-    texture.err_scope = err_scope
+    texture.err_data = err_data
 
     return texture, .No_Error
 }
@@ -978,7 +978,7 @@ device_get_limits :: proc(using self: ^Device) -> Limits {
 device_get_queue :: proc(using self: ^Device) -> Queue {
     gpu_queue := Queue {
         ptr       = wgpu.device_get_queue(ptr),
-        err_scope = err_scope,
+        err_data = err_data,
         vtable    = &default_queue_vtable,
     }
 
@@ -996,8 +996,8 @@ device_set_uncaptured_error_callback :: proc(
     callback: Error_Callback,
     user_data: rawptr,
 ) {
-    err_scope.user_cb = callback
-    err_scope.user_data = user_data
+    err_data.user_cb = callback
+    err_data.user_data = user_data
 }
 
 device_pop_error_scope :: proc(
@@ -1015,7 +1015,7 @@ device_push_error_scope :: proc(using self: ^Device, filter: Error_Filter) {
 // Get last error message. Ownership not transferred. String valid until next error or 
 // until device is released
 device_get_error_message :: proc(using self: ^Device) -> string {
-    return err_scope.message
+    return err_data.message
 }
 
 device_set_label :: proc(using self: ^Device, label: cstring) {
@@ -1030,8 +1030,8 @@ device_reference :: proc(using self: ^Device) {
 device_release :: proc(using self: ^Device) {
     if ptr != nil {
         delete(features)
-        delete(err_scope.message)
-        free(err_scope)
+        delete(err_data.message)
+        free(err_data)
         queue->release()
         wgpu.device_release(ptr)
     }

--- a/wrapper/error_scope.odin
+++ b/wrapper/error_scope.odin
@@ -7,7 +7,6 @@ import "core:strings"
 
 Error_Scope :: struct {
     type: Error_Type,
-    info: cstring,
     message: string,
     user_cb: Error_Callback,
     user_data: rawptr,

--- a/wrapper/errors.odin
+++ b/wrapper/errors.odin
@@ -5,14 +5,14 @@ package wgpu
 import "core:runtime"
 import "core:strings"
 
-Error_Scope :: struct {
+Error_Data :: struct {
     type: Error_Type,
     message: string,
     user_cb: Error_Callback,
     user_data: rawptr,
 }
 
-error_scope_callback := proc "c" (
+uncaptured_error_callback := proc "c" (
     type: Error_Type,
     message: cstring,
     user_data: rawptr,
@@ -21,7 +21,7 @@ error_scope_callback := proc "c" (
         return
     }
     context = runtime.default_context()
-    error := cast(^Error_Scope)user_data
+    error := cast(^Error_Data)user_data
     /* fmt.eprintf("ERROR - %s [%v]:\n\t%s\n", error.info, type, message) */
     if error.user_cb != nil do error.user_cb(type, message, error.user_data)
     error.type = type

--- a/wrapper/queue.odin
+++ b/wrapper/queue.odin
@@ -104,7 +104,7 @@ queue_write_buffer :: proc(
 ) -> (
     err: Error_Type,
 ) {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     data_size := cast(uint)len(data)
 
@@ -129,7 +129,7 @@ queue_write_texture :: proc(
 ) -> (
     err: Error_Type,
 ) {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     data_size := cast(uint)len(data)
 

--- a/wrapper/queue.odin
+++ b/wrapper/queue.odin
@@ -9,7 +9,7 @@ import wgpu "../bindings"
 // Handle to a command queue on a device.
 Queue :: struct {
     ptr:          WGPU_Queue,
-    err_scope: ^Error_Scope,
+    err_data: ^Error_Data,
     using vtable: ^Queue_VTable,
 }
 
@@ -104,7 +104,7 @@ queue_write_buffer :: proc(
 ) -> (
     err: Error_Type,
 ) {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     data_size := cast(uint)len(data)
 
@@ -116,7 +116,7 @@ queue_write_buffer :: proc(
     }
 
 
-    return err_scope.type
+    return err_data.type
 }
 
 // Schedule a write of some data into a texture.
@@ -129,7 +129,7 @@ queue_write_texture :: proc(
 ) -> (
     err: Error_Type,
 ) {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     data_size := cast(uint)len(data)
 
@@ -148,7 +148,7 @@ queue_write_texture :: proc(
     }
 
 
-    return err_scope.type
+    return err_data.type
 }
 
 queue_reference :: proc(using self: ^Queue) {

--- a/wrapper/swap_chain.odin
+++ b/wrapper/swap_chain.odin
@@ -5,7 +5,7 @@ import wgpu "../bindings"
 
 Swap_Chain :: struct {
     ptr:          WGPU_Swap_Chain,
-    err_scope: ^Error_Scope,
+    err_data: ^Error_Data,
     using vtable: ^Swap_Chain_VTable,
 }
 
@@ -37,15 +37,15 @@ swap_chain_get_current_texture_view :: proc(
     Texture_View,
     Error_Type,
 ) {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     texture_view_ptr := wgpu.swap_chain_get_current_texture_view(ptr)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if texture_view_ptr != nil {
             wgpu.texture_view_release(texture_view_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     texture_view := default_texture_view

--- a/wrapper/swap_chain.odin
+++ b/wrapper/swap_chain.odin
@@ -37,7 +37,7 @@ swap_chain_get_current_texture_view :: proc(
     Texture_View,
     Error_Type,
 ) {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     texture_view_ptr := wgpu.swap_chain_get_current_texture_view(ptr)
 

--- a/wrapper/texture.odin
+++ b/wrapper/texture.odin
@@ -5,7 +5,7 @@ import wgpu "../bindings"
 
 Texture :: struct {
     ptr:          WGPU_Texture,
-    err_scope:    ^Error_Scope,
+    err_data:    ^Error_Data,
     using vtable: ^Texture_VTable,
 }
 
@@ -63,15 +63,15 @@ texture_create_view :: proc(
     Texture_View,
     Error_Type,
 ) {
-    err_scope.type = .No_Error
+    err_data.type = .No_Error
 
     texture_view_ptr := wgpu.texture_create_view(ptr, descriptor)
 
-    if err_scope.type != .No_Error {
+    if err_data.type != .No_Error {
         if texture_view_ptr != nil {
             wgpu.texture_view_release(texture_view_ptr)
         }
-        return {}, err_scope.type
+        return {}, err_data.type
     }
 
     texture_view := default_texture_view

--- a/wrapper/texture.odin
+++ b/wrapper/texture.odin
@@ -63,7 +63,7 @@ texture_create_view :: proc(
     Texture_View,
     Error_Type,
 ) {
-    err_scope.info = #procedure
+    err_scope.type = .No_Error
 
     texture_view_ptr := wgpu.texture_create_view(ptr, descriptor)
 


### PR DESCRIPTION
Resets the error type in the appropriate places to prevent unintended behaviour when two errors occur in a row, also removed the error info field as it's no longer used and a useful enough procedure name is already given in the builtin error messages. Also renames some things to better reflect how they are now used.

I'm thinking of changing some stuff with the request adapter and device error handling to make it more consistent with device errors next. But this PR should be safe to merge as is.