### PR TITLE
Update Examples to use new error handling

### DIFF
--- a/examples/info/info.odin
+++ b/examples/info/info.odin
@@ -29,7 +29,10 @@ main :: proc() {
     adapter, adapter_err := instance->request_adapter(
         &{power_preference = .High_Performance},
     )
-    if adapter_err != .No_Error do return
+    if adapter_err != .No_Error {
+        fmt.eprintln("ERROR Creating Adapter:", wgpu.get_error_message())
+        return
+    }
     defer adapter->release()
 
     print_adapter_information(adapter.info)

--- a/examples/learn_wgpu/beginner/tutorial2_surface/tutorial2_surface.odin
+++ b/examples/learn_wgpu/beginner/tutorial2_surface/tutorial2_surface.odin
@@ -177,7 +177,15 @@ main :: proc() {
     }
 
     state, state_err := init_state(sdl_window)
-    if state_err != .No_Error do return
+    if state_err != .No_Error {
+        message := wgpu.get_error_message()
+        if message != "" {
+            fmt.eprintln("ERROR: Failed to initilize program:", message)
+        } else {
+            fmt.eprintln("ERROR: Failed to initilize program")
+        }
+        return
+    }
     defer {
         state.device->release()
         state.surface->release()
@@ -219,7 +227,7 @@ main :: proc() {
     }
 
     if err != .No_Error {
-        fmt.eprintf("Error occurred while rendering: %v\n", err)
+        fmt.eprintf("Error occurred while rendering: %v\n", wgpu.get_error_message())
     }
 
     fmt.println("Exiting...")

--- a/examples/learn_wgpu/beginner/tutorial2_surface_challenge/tutorial2_surface_challenge.odin
+++ b/examples/learn_wgpu/beginner/tutorial2_surface_challenge/tutorial2_surface_challenge.odin
@@ -182,7 +182,15 @@ main :: proc() {
     }
 
     state, state_err := init_state(sdl_window)
-    if state_err != .No_Error do return
+    if state_err != .No_Error {
+        message := wgpu.get_error_message()
+        if message != "" {
+            fmt.eprintln("ERROR: Failed to initilize program:", message)
+        } else {
+            fmt.eprintln("ERROR: Failed to initilize program")
+        }
+        return
+    }
     defer {
         state.device->release()
         state.surface->release()
@@ -232,7 +240,7 @@ main :: proc() {
     }
 
     if err != .No_Error {
-        fmt.eprintf("Error occurred while rendering: %v\n", err)
+        fmt.eprintf("Error occurred while rendering: %v\n", wgpu.get_error_message())
     }
 
     fmt.println("Exiting...")

--- a/examples/learn_wgpu/beginner/tutorial3_pipeline/tutorial3_pipeline.odin
+++ b/examples/learn_wgpu/beginner/tutorial3_pipeline/tutorial3_pipeline.odin
@@ -215,7 +215,15 @@ main :: proc() {
     }
 
     state, state_err := init_state(sdl_window)
-    if state_err != .No_Error do return
+    if state_err != .No_Error {
+        message := wgpu.get_error_message()
+        if message != "" {
+            fmt.eprintln("ERROR: Failed to initilize program:", message)
+        } else {
+            fmt.eprintln("ERROR: Failed to initilize program")
+        }
+        return
+    }
     defer {
         state.render_pipeline->release()
         state.device->release()
@@ -258,7 +266,7 @@ main :: proc() {
     }
 
     if err != .No_Error {
-        fmt.eprintf("Error occurred while rendering: %v\n", err)
+        fmt.eprintf("Error occurred while rendering: %v\n", wgpu.get_error_message())
     }
 
     fmt.println("Exiting...")

--- a/examples/learn_wgpu/beginner/tutorial3_pipeline_challenge/tutorial3_pipeline_challenge.odin
+++ b/examples/learn_wgpu/beginner/tutorial3_pipeline_challenge/tutorial3_pipeline_challenge.odin
@@ -254,7 +254,15 @@ main :: proc() {
     }
 
     state, state_err := init_state(sdl_window)
-    if state_err != .No_Error do return
+    if state_err != .No_Error {
+        message := wgpu.get_error_message()
+        if message != "" {
+            fmt.eprintln("ERROR: Failed to initilize program:", message)
+        } else {
+            fmt.eprintln("ERROR: Failed to initilize program")
+        }
+        return
+    }
     defer {
         state.challenge_render_pipeline->release()
         state.render_pipeline->release()
@@ -309,7 +317,7 @@ main :: proc() {
     }
 
     if err != .No_Error {
-        fmt.eprintf("Error occurred while rendering: %v\n", err)
+        fmt.eprintf("Error occurred while rendering: %v\n", wgpu.get_error_message())
     }
 
     fmt.println("Exiting...")

--- a/examples/learn_wgpu/beginner/tutorial4_buffer/tutorial4_buffer.odin
+++ b/examples/learn_wgpu/beginner/tutorial4_buffer/tutorial4_buffer.odin
@@ -282,7 +282,15 @@ main :: proc() {
     }
 
     state, state_err := init_state(sdl_window)
-    if state_err != .No_Error do return
+    if state_err != .No_Error {
+        message := wgpu.get_error_message()
+        if message != "" {
+            fmt.eprintln("ERROR: Failed to initilize program:", message)
+        } else {
+            fmt.eprintln("ERROR: Failed to initilize program")
+        }
+        return
+    }
     defer {
         state.render_pipeline->release()
         state.index_buffer->release()
@@ -327,7 +335,7 @@ main :: proc() {
     }
 
     if err != .No_Error {
-        fmt.eprintf("Error occurred while rendering: %v\n", err)
+        fmt.eprintf("Error occurred while rendering: %v\n", wgpu.get_error_message())
     }
 
     fmt.println("Exiting...")

--- a/examples/learn_wgpu/beginner/tutorial4_buffer_challenge/tutorial4_buffer_challenge.odin
+++ b/examples/learn_wgpu/beginner/tutorial4_buffer_challenge/tutorial4_buffer_challenge.odin
@@ -343,7 +343,15 @@ main :: proc() {
     }
 
     state, state_err := init_state(sdl_window)
-    if state_err != .No_Error do return
+    if state_err != .No_Error {
+        message := wgpu.get_error_message()
+        if message != "" {
+            fmt.eprintln("ERROR: Failed to initilize program:", message)
+        } else {
+            fmt.eprintln("ERROR: Failed to initilize program")
+        }
+        return
+    }
     defer {
         state.challenge_vertex_buffer->release()
         state.challenge_index_buffer->release()
@@ -400,7 +408,7 @@ main :: proc() {
     }
 
     if err != .No_Error {
-        fmt.eprintf("Error occurred while rendering: %v\n", err)
+        fmt.eprintf("Error occurred while rendering: %v\n", wgpu.get_error_message())
     }
 
     fmt.println("Exiting...")

--- a/examples/simple_compute/simple_compute.odin
+++ b/examples/simple_compute/simple_compute.odin
@@ -31,7 +31,10 @@ main :: proc() {
     adapter, adapter_err := instance->request_adapter(
         &{compatible_surface = nil, power_preference = .High_Performance},
     )
-    if adapter_err != .No_Error do return
+    if adapter_err != .No_Error {
+        fmt.eprintln("ERROR Couldn't Request Adapter:", wgpu.get_error_message())
+        return
+    }
     defer adapter->release()
 
     // Device
@@ -40,8 +43,16 @@ main :: proc() {
     }
 
     device, device_err := adapter->request_device(&device_options)
-    if device_err != .No_Error do return
+    if device_err != .No_Error {
+        fmt.eprintln("ERROR Couldn't Request Adapter:", wgpu.get_error_message())
+        return
+    }
     defer device->release()
+
+    device->set_uncaptured_error_callback(proc "c" (type: wgpu.Error_Type, message: cstring, user_data: rawptr) {
+        context = runtime.default_context()
+        fmt.eprintln("ERROR:", message)
+    }, nil)
 
     // Shader module
     module, module_err := device->load_wgsl_shader_module(

--- a/examples/triangle/triangle.odin
+++ b/examples/triangle/triangle.odin
@@ -54,7 +54,7 @@ init_state := proc(window: ^sdl.Window) -> (s: State, err: wgpu.Error_Type) {
 
     // Adapter
     adapter := state.instance->request_adapter(
-        &{compatible_surface = &state.surface, power_preference = .High_Performance},
+            &{compatible_surface = &state.surface, power_preference = .High_Performance},
     ) or_return
     defer adapter->release()
 
@@ -266,7 +266,15 @@ main :: proc() {
     }
 
     state, state_err := init_state(sdl_window)
-    if state_err != .No_Error do return
+    if state_err != .No_Error {
+        message := wgpu.get_error_message()
+        if message != "" {
+            fmt.eprintln("ERROR: Failed to initilize program:", message)
+        } else {
+            fmt.eprintln("ERROR: Failed to initilize program")
+        }
+        return
+    }
     defer {
         when TRIANGLE_MSAA_EXAMPLE {
             state.multisampled_framebuffer->release()
@@ -278,7 +286,7 @@ main :: proc() {
         state.instance->release()
     }
 
-    err := wgpu.Error_Type{}
+    err: wgpu.Error_Type
 
     main_loop: for {
         e: sdl.Event
@@ -315,7 +323,7 @@ main :: proc() {
     }
 
     if err != .No_Error {
-        fmt.eprintf("Error occurred while rendering: %v\n", err)
+        fmt.eprintf("Error occurred while rendering: %v\n", wgpu.get_error_message())
     }
 
     fmt.println("Exiting...")


### PR DESCRIPTION
It's not perfect because create_instance and create_surface still just print their errors, but the examples shouldn't need changing if those procedures are updated.