### PR TITLE
Fix potential undefined behaviour in `adapter_request_device`

### DIFF
--- a/wrapper/adapter.odin
+++ b/wrapper/adapter.odin
@@ -156,10 +156,9 @@ adapter_request_device :: proc(
     err: Error_Type,
 ) {
     // Default descriptor can be NULL...
-    desc: ^wgpu.Device_Descriptor = nil
+    desc: ^wgpu.Device_Descriptor = nil if descriptor == nil else &{}
 
     if descriptor != nil {
-        desc = &wgpu.Device_Descriptor{}
 
         if descriptor.label != nil && descriptor.label != "" {
             desc.label = descriptor.label

--- a/wrapper/adapter.odin
+++ b/wrapper/adapter.odin
@@ -157,6 +157,7 @@ adapter_request_device :: proc(
 ) {
     // Default descriptor can be NULL...
     desc: ^wgpu.Device_Descriptor = nil if descriptor == nil else &{}
+    res: Device_Response
 
     if descriptor != nil {
 
@@ -250,10 +251,13 @@ adapter_request_device :: proc(
                 trace_path = descriptor.trace_path,
             }
         }
+
+        // NOTE(JopStro): Quick and dirty fix to avoid scope issues, more elegant solutions welcome
+        wgpu.adapter_request_device(ptr, desc, _on_adapter_request_device, &res)
+    } else {
+        wgpu.adapter_request_device(ptr, desc, _on_adapter_request_device, &res)
     }
 
-    res := Device_Response{}
-    wgpu.adapter_request_device(ptr, desc, _on_adapter_request_device, &res)
 
     if res.status != .Success {
         return {}, .Unknown


### PR DESCRIPTION
Pointer compound literals are allocated in the scope they are written in so accessing it outside of that scope is undefined (assuming odin's behaviour here is consistent with C)