### PR TITLE
Make `to_bytes` accept more types

### DIFF
--- a/wrapper/buffer_ext.odin
+++ b/wrapper/buffer_ext.odin
@@ -11,11 +11,13 @@ CHECK_TO_BYTES :: #config(WGPU_CHECK_TO_BYTES,true)
 @(private="file")
 can_be_bytes :: proc(T: typeid) -> bool {
     id := reflect.typeid_core(T)
-    for reflect.type_kind(id) == .Array || reflect.type_kind(id) == .Enumerated_Array {
+    kind := reflect.type_kind(id)
+    for kind == .Array || kind == .Enumerated_Array {
         id = reflect.typeid_elem(id)
         id = reflect.typeid_core(id)
+        kind = reflect.type_kind(id)
     }
-    #partial switch reflect.type_kind(id) {
+    #partial switch kind {
     case .Struct:
         res := true
         for ti in reflect.struct_field_types(id) {

--- a/wrapper/buffer_ext.odin
+++ b/wrapper/buffer_ext.odin
@@ -1,6 +1,89 @@
 package wgpu
 
 import "core:slice"
+import "core:reflect"
+import "core:fmt"
 
 from_bytes :: slice.reinterpret
-to_bytes :: slice.to_bytes
+
+CHECK_TO_BYTES :: #config(WGPU_CHECK_TO_BYTES, true)
+
+@(private="file")
+can_be_bytes :: proc(T: typeid) -> bool {
+    id := reflect.typeid_core(T)
+    for reflect.type_kind(id) == .Array || reflect.type_kind(id) == .Enumerated_Array {
+        id = reflect.typeid_elem(id)
+        id = reflect.typeid_core(id)
+    }
+    #partial switch reflect.type_kind(id) {
+    case .Struct:
+        res := false
+        for ti in reflect.struct_field_types(id) {
+            res ||= can_be_bytes(ti.id)
+        }
+        return res
+    case .Union:
+        res := false
+        for ti in type_info_of(id).variant.(reflect.Type_Info_Union).variants {
+            res ||= can_be_bytes(ti.id)
+        }
+        return res
+    case .Slice,
+         .Dynamic_Array,
+         .Map,
+         .Pointer,
+         .Multi_Pointer,
+         .String,
+         .Procedure,
+         .Type_Id,
+         .Any,
+         .Soa_Pointer,
+         .Simd_Vector,
+         .Relative_Pointer,
+         .Relative_Multi_Pointer:
+        return false
+    }
+
+    return true
+}
+dynamic_array_to_bytes :: proc(arr: $T/[dynamic]$E) -> []u8 {
+    when CHECK_TO_BYTES {
+        if can_be_bytes(E) {
+            return slice.to_bytes(arr[:])
+        } else do fmt.panicf("Cannot fully convert to bytes: %v", typeid_of(T))
+    } else {
+        return slice.to_bytes(arr[:])
+    }
+}
+slice_to_bytes :: proc(s: $T/[]$E) -> []u8 {
+    when CHECK_TO_BYTES {
+        if can_be_bytes(E) {
+            return slice.to_bytes(s)
+        } else do fmt.panicf("Cannot fully convert to bytes: %v", typeid_of(T))
+    } else {
+        return slice.to_bytes(s)
+    }
+}
+
+// Compile time panic stub
+@(private="file")
+map_to_bytes :: proc(m: $T/map[$K]$V) -> []u8 {
+    #panic("Cannot fully convert map to bytes")
+}
+
+any_to_bytes :: proc(v: any) -> []u8 {
+    when CHECK_TO_BYTES {
+        if can_be_bytes(v.id) {
+            return reflect.as_bytes(v)
+        } else do fmt.panicf("Cannot fully convert to bytes: %v", v.id)
+    } else {
+        return reflect.as_bytes(v)
+    }
+}
+
+to_bytes :: proc {
+    slice_to_bytes,
+    dynamic_array_to_bytes,
+    map_to_bytes,
+    any_to_bytes,
+}

--- a/wrapper/buffer_ext.odin
+++ b/wrapper/buffer_ext.odin
@@ -17,13 +17,13 @@ can_be_bytes :: proc(T: typeid) -> bool {
     }
     #partial switch reflect.type_kind(id) {
     case .Struct:
-        res := false
+        res := true
         for ti in reflect.struct_field_types(id) {
             res &&= can_be_bytes(ti.id)
         }
         return res
     case .Union:
-        res := false
+        res := true
         for ti in type_info_of(id).variant.(reflect.Type_Info_Union).variants {
             res &&= can_be_bytes(ti.id)
         }

--- a/wrapper/buffer_ext.odin
+++ b/wrapper/buffer_ext.odin
@@ -6,7 +6,7 @@ import "core:fmt"
 
 from_bytes :: slice.reinterpret
 
-CHECK_TO_BYTES :: #config(WGPU_CHECK_TO_BYTES, true)
+CHECK_TO_BYTES :: #config(WGPU_CHECK_TO_BYTES,true)
 
 @(private="file")
 can_be_bytes :: proc(T: typeid) -> bool {
@@ -19,13 +19,13 @@ can_be_bytes :: proc(T: typeid) -> bool {
     case .Struct:
         res := false
         for ti in reflect.struct_field_types(id) {
-            res ||= can_be_bytes(ti.id)
+            res &&= can_be_bytes(ti.id)
         }
         return res
     case .Union:
         res := false
         for ti in type_info_of(id).variant.(reflect.Type_Info_Union).variants {
-            res ||= can_be_bytes(ti.id)
+            res &&= can_be_bytes(ti.id)
         }
         return res
     case .Slice,


### PR DESCRIPTION
Makes `to_bytes` accept anything with, mostly runtime, type checking to prevent dumb mistakes. Also adds a compile option `WGPU_CHECK_TO_BYTES` to disable the type checking for release builds in a similar vein to odin's bounds checking option.

The main motivation for this is to make it easier to copy uniforms to the GPU.
I desperately tried to get a compile time safe version working with parapoly to no avail, maybe if odin ever gets more robust metaprogramming features that could be an option.