### PR TITLE
Fix: empty project linkage errors

### DIFF
--- a/bindings/wgpu_native.odin
+++ b/bindings/wgpu_native.odin
@@ -1,5 +1,21 @@
 package wgpu_bindings
 
+when ODIN_OS == .Windows {
+	when WGPU_SHARED {
+		foreign import wgpu_native {LIB}
+	} else {
+		foreign import wgpu_native {LIB}
+	}
+} else when ODIN_OS == .Darwin || ODIN_OS == .Linux {
+	when WGPU_USE_SYSTEM_LIBRARIES {
+		foreign import wgpu_native "system:wgpu_native"
+	} else {
+		foreign import wgpu_native {LIB}
+	}
+} else {
+	foreign import wgpu_native "system:wgpu_native"
+}
+
 Native_SType :: enum ENUM_SIZE {
 	Device_Extras                  = 0x00030001,
 	Required_Limits_Extras         = 0x00030002,
@@ -250,7 +266,7 @@ Native_Texture_Format :: enum ENUM_SIZE {
 }
 
 @(default_calling_convention = "c")
-foreign _ {
+foreign wgpu_native {
 	@(link_name = "wgpuGenerateReport")
 	generate_report :: proc(instance: Instance, report: ^Global_Report) ---
 

--- a/bindings/wgpu_native.odin
+++ b/bindings/wgpu_native.odin
@@ -4,7 +4,21 @@ when ODIN_OS == .Windows {
 	when WGPU_SHARED {
 		foreign import wgpu_native {LIB}
 	} else {
-		foreign import wgpu_native {LIB}
+		foreign import wgpu_native {
+			LIB,
+			"system:gdi32.lib",
+			"system:dxgi.lib",
+			"system:d3dcompiler.lib",
+			"system:opengl32.lib",
+			"system:user32.lib",
+			"system:dwmapi.lib",
+			"system:bcrypt.lib",
+			"system:ws2_32.lib",
+			"system:userenv.lib",
+			"system:dbghelp.lib",
+			"system:advapi32.lib",
+			"system:ntdll.lib",
+		}
 	}
 } else when ODIN_OS == .Darwin || ODIN_OS == .Linux {
 	when WGPU_USE_SYSTEM_LIBRARIES {


### PR DESCRIPTION
Hello. This PR fixes a really strange issue that can be encountered when the package is referenced in code, but none of its functions are actually called. Consider the following example:
```go
package info

import wgpu "shared:wgpu/wrapper"

main :: proc() {}

_ :: wgpu
```
This snippet of code fails with the following error on MacOs Sequoia 15.1.1 arm:
```
Undefined symbols for architecture arm64:
  "_wgpuGetVersion", referenced from:
      _wgpu.get_raw_version in odin_fb.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This issue is caused by the function `_version_check` which is defined as `@init` and uses `wgpu.get_version`. This, in conjunction with the fact that  the `get_version` procedure is defined in an anonymous foreign block (`foreign import _`), gets the odin compiler confused if the package is included but not used. This causes odin to not link the wgpu library, whilst in reality it is needed.

The fix seems to make the anonymous foreign block named (changing it to `foreign import wgpu_native`). Please note that `wgpu_native` had to be redefined also in `wgpu_native.odin` because a foreign declaration is local to a specific file.

I am aware that this fix is not really elegant, but alternative solutions (like specifying the linkage type) do not seem to work.